### PR TITLE
Prepare for 1.2.4 release "Kalalau trail"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,13 @@ jobs:
 
       - name: Build new docker image
         if: env.MATCHED_FILES
-        run: docker build --no-cache . -t nfcore/diaproteomics:1.2.3
+        run: docker build --no-cache . -t nfcore/diaproteomics:dev
 
       - name: Pull docker image
         if: ${{ !env.MATCHED_FILES }}
         run: |
           docker pull nfcore/diaproteomics:dev
-          docker tag nfcore/diaproteomics:dev nfcore/diaproteomics:1.2.3
+          docker tag nfcore/diaproteomics:dev nfcore/diaproteomics:dev
 
       - name: Install Nextflow
         env:
@@ -75,13 +75,13 @@ jobs:
 
       - name: Build new docker image
         if: env.GIT_DIFF
-        run: docker build --no-cache . -t nfcore/diaproteomics:1.2.3
+        run: docker build --no-cache . -t nfcore/diaproteomics:dev
 
       - name: Pull docker image
         if: ${{ !env.GIT_DIFF }}
         run: |
           docker pull nfcore/diaproteomics:dev
-          docker tag nfcore/diaproteomics:dev nfcore/diaproteomics:1.2.3
+          docker tag nfcore/diaproteomics:dev nfcore/diaproteomics:dev
 
       - name: Install Nextflow
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,13 @@ jobs:
 
       - name: Build new docker image
         if: env.MATCHED_FILES
-        run: docker build --no-cache . -t nfcore/diaproteomics:dev
+        run: docker build --no-cache . -t nfcore/diaproteomics:1.2.4
 
       - name: Pull docker image
         if: ${{ !env.MATCHED_FILES }}
         run: |
           docker pull nfcore/diaproteomics:dev
-          docker tag nfcore/diaproteomics:dev nfcore/diaproteomics:dev
+          docker tag nfcore/diaproteomics:dev nfcore/diaproteomics:1.2.4
 
       - name: Install Nextflow
         env:
@@ -75,13 +75,13 @@ jobs:
 
       - name: Build new docker image
         if: env.GIT_DIFF
-        run: docker build --no-cache . -t nfcore/diaproteomics:dev
+        run: docker build --no-cache . -t nfcore/diaproteomics:1.2.4
 
       - name: Pull docker image
         if: ${{ !env.GIT_DIFF }}
         run: |
           docker pull nfcore/diaproteomics:dev
-          docker tag nfcore/diaproteomics:dev nfcore/diaproteomics:dev
+          docker tag nfcore/diaproteomics:dev nfcore/diaproteomics:1.2.4
 
       - name: Install Nextflow
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,13 @@ jobs:
 
       - name: Build new docker image
         if: env.MATCHED_FILES
-        run: docker build --no-cache . -t nfcore/diaproteomics:1.2.4
+        run: docker build --no-cache . -t nfcore/diaproteomics:dev
 
       - name: Pull docker image
         if: ${{ !env.MATCHED_FILES }}
         run: |
           docker pull nfcore/diaproteomics:dev
-          docker tag nfcore/diaproteomics:dev nfcore/diaproteomics:1.2.4
+          docker tag nfcore/diaproteomics:dev nfcore/diaproteomics:dev
 
       - name: Install Nextflow
         env:
@@ -75,13 +75,13 @@ jobs:
 
       - name: Build new docker image
         if: env.GIT_DIFF
-        run: docker build --no-cache . -t nfcore/diaproteomics:1.2.4
+        run: docker build --no-cache . -t nfcore/diaproteomics:dev
 
       - name: Pull docker image
         if: ${{ !env.GIT_DIFF }}
         run: |
           docker pull nfcore/diaproteomics:dev
-          docker tag nfcore/diaproteomics:dev nfcore/diaproteomics:1.2.4
+          docker tag nfcore/diaproteomics:dev nfcore/diaproteomics:dev
 
       - name: Install Nextflow
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## v.1.2.4dev - [27.04.21]
+
 - Raise memory requirements for FDR estimation
 
 ## v.1.2.3 - [26.04.21]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v.1.2.4 - [27.04.21]
 
-- Raise memory requirements for FDR estimation
+- Raise memory requirements for FDR estimation and output visualization
 
 ## v.1.2.3 - [26.04.21]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v.1.2.4dev - [27.04.21]
+- Raise memory requirements for FDR estimation
+
 ## v.1.2.3 - [26.04.21]
 
 - Optional mzTab output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v.1.2.4dev - [27.04.21]
+## v.1.2.4 - [27.04.21]
 
 - Raise memory requirements for FDR estimation
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ COPY environment.yml /
 RUN conda env create --quiet -f /environment.yml && conda clean -a
 
 # Add conda installation dir to PATH (instead of doing 'conda activate')
-ENV PATH /opt/conda/envs/nf-core-diaproteomics-1.2.4/bin:$PATH
+ENV PATH /opt/conda/envs/nf-core-diaproteomics-1.2.4dev/bin:$PATH
 
 # Dump the details of the installed packages to a file for posterity
-RUN conda env export --name nf-core-diaproteomics-1.2.4 > nf-core-diaproteomics-1.2.4.yml
+RUN conda env export --name nf-core-diaproteomics-1.2.4dev > nf-core-diaproteomics-1.2.4dev.yml
 
 # Install DIAlignR from GitHub
 RUN Rscript -e 'remotes::install_github("shubham1637/DIAlignR@2119587", dependencies=FALSE)'

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ COPY environment.yml /
 RUN conda env create --quiet -f /environment.yml && conda clean -a
 
 # Add conda installation dir to PATH (instead of doing 'conda activate')
-ENV PATH /opt/conda/envs/nf-core-diaproteomics-1.2.4dev/bin:$PATH
+ENV PATH /opt/conda/envs/nf-core-diaproteomics-1.2.4/bin:$PATH
 
 # Dump the details of the installed packages to a file for posterity
-RUN conda env export --name nf-core-diaproteomics-1.2.4dev > nf-core-diaproteomics-1.2.4dev.yml
+RUN conda env export --name nf-core-diaproteomics-1.2.4 > nf-core-diaproteomics-1.2.4.yml
 
 # Install DIAlignR from GitHub
 RUN Rscript -e 'remotes::install_github("shubham1637/DIAlignR@2119587", dependencies=FALSE)'

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ COPY environment.yml /
 RUN conda env create --quiet -f /environment.yml && conda clean -a
 
 # Add conda installation dir to PATH (instead of doing 'conda activate')
-ENV PATH /opt/conda/envs/nf-core-diaproteomics-1.2.3/bin:$PATH
+ENV PATH /opt/conda/envs/nf-core-diaproteomics-1.2.4dev/bin:$PATH
 
 # Dump the details of the installed packages to a file for posterity
-RUN conda env export --name nf-core-diaproteomics-1.2.3 > nf-core-diaproteomics-1.2.3.yml
+RUN conda env export --name nf-core-diaproteomics-1.2.4dev > nf-core-diaproteomics-1.2.4dev.yml
 
 # Install DIAlignR from GitHub
 RUN Rscript -e 'remotes::install_github("shubham1637/DIAlignR@2119587", dependencies=FALSE)'

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -35,6 +35,7 @@ params {
   force_option = true                // specification that the OpenSwathWorkflow should be forced to run despite warnings
   generate_plots = true
   run_msstats = true
+  use_ms1 = false
 
   // Input data
   input = 'https://raw.githubusercontent.com/nf-core/test-datasets/diaproteomics/sample_sheet_full.tsv'

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 # You can use this file to create a conda environment for this pipeline:
 #   conda env create -f environment.yml
-name: nf-core-diaproteomics-1.2.3
+name: nf-core-diaproteomics-1.2.4dev
 channels:
   - conda-forge
   - bioconda

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 # You can use this file to create a conda environment for this pipeline:
 #   conda env create -f environment.yml
-name: nf-core-diaproteomics-1.2.4dev
+name: nf-core-diaproteomics-1.2.4
 channels:
   - conda-forge
   - bioconda

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 # You can use this file to create a conda environment for this pipeline:
 #   conda env create -f environment.yml
-name: nf-core-diaproteomics-1.2.4
+name: nf-core-diaproteomics-1.2.4dev
 channels:
   - conda-forge
   - bioconda

--- a/main.nf
+++ b/main.nf
@@ -674,7 +674,7 @@ process dia_search_output_merging {
 process global_false_discovery_rate_estimation {
     publishDir "${params.outdir}/pyprophet_output"
 
-    label 'process_medium'
+    label 'process_high_mem'
 
     input:
     set val(id), val(sample), val(condition), file(scored_osw) from merged_osw_file_for_global

--- a/main.nf
+++ b/main.nf
@@ -984,7 +984,7 @@ process statistical_post_processing {
 process output_visualization {
     publishDir "${params.outdir}/"
 
-    label 'process_low'
+    label 'process_high'
 
     input:
     set val(sample), val(id), val(condition), file(quantity_csv_file), val(dummy_id), val(dummy_condition), file(pyprophet_tsv_file) from DIALignR_result_I.transpose().join(pyprophet_results, by:1)

--- a/nextflow.config
+++ b/nextflow.config
@@ -98,7 +98,7 @@ params {
 
 // Container slug. Stable releases should specify release tag!
 // Developmental code should specify :dev
-process.container = 'nfcore/diaproteomics:1.2.3'
+process.container = 'nfcore/diaproteomics:dev'
 
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
@@ -206,7 +206,7 @@ manifest {
   description = 'Automated quantitative analysis of DIA proteomics mass spectrometry measurements.'
   mainScript = 'main.nf'
   nextflowVersion = '>=20.04.0'
-  version = '1.2.3'
+  version = '1.2.4dev'
 }
 
 // Function to ensure that resource requirements don't go beyond

--- a/nextflow.config
+++ b/nextflow.config
@@ -98,7 +98,7 @@ params {
 
 // Container slug. Stable releases should specify release tag!
 // Developmental code should specify :dev
-process.container = 'nfcore/diaproteomics:dev'
+process.container = 'nfcore/diaproteomics:1.2.4'
 
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
@@ -206,7 +206,7 @@ manifest {
   description = 'Automated quantitative analysis of DIA proteomics mass spectrometry measurements.'
   mainScript = 'main.nf'
   nextflowVersion = '>=20.04.0'
-  version = '1.2.4dev'
+  version = '1.2.4'
 }
 
 // Function to ensure that resource requirements don't go beyond

--- a/nextflow.config
+++ b/nextflow.config
@@ -98,7 +98,7 @@ params {
 
 // Container slug. Stable releases should specify release tag!
 // Developmental code should specify :dev
-process.container = 'nfcore/diaproteomics:1.2.4'
+process.container = 'nfcore/diaproteomics:dev'
 
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
@@ -206,7 +206,7 @@ manifest {
   description = 'Automated quantitative analysis of DIA proteomics mass spectrometry measurements.'
   mainScript = 'main.nf'
   nextflowVersion = '>=20.04.0'
-  version = '1.2.4'
+  version = '1.2.4dev'
 }
 
 // Function to ensure that resource requirements don't go beyond


### PR DESCRIPTION
This PR will change the default memory requirements for the false discovery estimation and output visualization.

It therefore fixes the problems encountered when running it on the AWS system. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
  - [x] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
  - [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/diaproteomics/tree/master/.github/CONTRIBUTING.md)
  - [x] If necessary, also make a PR on the nf-core/diaproteomics _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
