### PR TITLE
Remove code duplication in ci actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,30 @@ on:
 
 jobs:
   test:
-    name: Run workflow tests
+    name: Run wf
     # Only run on push if this is the nf-core dev branch (merged PRs)
     if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/diaproteomics') }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        profile:
+          - test
+          - test_with_library
+          - test_skip_processing
+          - test_no_align
+          - test_no_merge
+          - test_with_library_with_decoys
+          - test_with_library_without_irts
+          - test_without_library_with_irts
+        # Nextflow version: current latest
+        nxf_ver: ['']
+        # Nextflow version: pipeline minimum for just the test profile, not all test profiles
+        include:
+          - profile: test
+            nxf_ver: '20.04.0'
     env:
       NXF_VER: ${{ matrix.nxf_ver }}
       NXF_ANSI_LOG: false
-    strategy:
-      matrix:
-        # Nextflow versions: check pipeline minimum and current latest
-        nxf_ver: ['20.04.0', '']
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2
@@ -53,46 +66,4 @@ jobs:
           sudo mv nextflow /usr/local/bin/
 
       - name: Run pipeline with test data
-        # For example: adding multiple test runs with different parameters
-        # Remember that you can parallelise this by using strategy.matrix
-        run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker
-
-  profile:
-    env:
-      NXF_ANSI_LOG: false
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        profile: [test_with_library, test_skip_processing, test_no_align, test_no_merge, test_with_library_with_decoys, test_with_library_without_irts, test_without_library_with_irts]
-    steps:
-      - name: Check out pipeline code
-        uses: actions/checkout@v2
-
-      - name: Check if Dockerfile or Conda environment changed
-        uses: technote-space/get-diff-action@v4
-        with:
-          PREFIX_FILTER: |
-            Dockerfile
-            environment.yml
-
-      - name: Build new docker image
-        if: env.GIT_DIFF
-        run: docker build --no-cache . -t nfcore/diaproteomics:dev
-
-      - name: Pull docker image
-        if: ${{ !env.GIT_DIFF }}
-        run: |
-          docker pull nfcore/diaproteomics:dev
-          docker tag nfcore/diaproteomics:dev nfcore/diaproteomics:dev
-
-      - name: Install Nextflow
-        run: |
-          wget -qO- get.nextflow.io | bash
-          sudo mv nextflow /usr/local/bin/
-        env:
-          # Only check Nextflow pipeline minimum version
-          NXF_VER: '20.04.0'
-
-      - name: Run ${{ matrix.profile }} test
         run: nextflow run ${GITHUB_WORKSPACE} -profile ${{ matrix.profile }},docker

--- a/.nf-core-lint.yml
+++ b/.nf-core-lint.yml
@@ -2,3 +2,6 @@
 files_unchanged:
   - .github/CONTRIBUTING.md
   - assets/sendmail_template.txt
+# Temporary - ignore actions CI lint test until tools is updated with this code style
+# See https://github.com/nf-core/diaproteomics/pull/131
+actions_ci: False


### PR DESCRIPTION
Currently, the CI workflow for testing the pipeline has two jobs in it which are nearly identical. I think that this is because you didn't want to run 2x versions of Nextflow across multiple test profiles.

Here I have collapsed the two into one job and used the GitHub Actions `include` statement to have a single workflow run with the minimum Nextflow version in addition to all profiles with the latest version. So the functionality should be the same, but without the code duplication.

This is the first time I've attempted this in an actions workflow, so we will have to see if it works!

Note that the `nf-core lint` command will probably fail as I think it checks for the minimum nextflow version.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/diaproteomics/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/diaproteomics _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
