### PR TITLE
Use mamba to build the environment instead of conda

### DIFF
--- a/.nf-core-lint.yml
+++ b/.nf-core-lint.yml
@@ -5,3 +5,5 @@ files_unchanged:
 # Temporary - ignore actions CI lint test until tools is updated with this code style
 # See https://github.com/nf-core/diaproteomics/pull/131
 actions_ci: False
+# Switched to mamba because conda refuses to build
+conda_dockerfile: False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v.1.2.5dev - [12.05.21]
 
 - Template update 1.14
+- Use `mamba` to build the conda environment instead of `conda` (which was failing)
 
 ## v.1.2.4 - [27.04.21]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,18 @@ FROM nfcore/base:1.14
 LABEL authors="Leon Bichmann" \
       description="Docker image containing all software requirements for the nf-core/diaproteomics pipeline"
 
+# Install mamba
+RUN conda install mamba -n base -c conda-forge
+
 # Install the conda environment
 COPY environment.yml /
-RUN conda env create --quiet -f /environment.yml && conda clean -a
+RUN mamba env create --quiet -f /environment.yml && mamba clean -a
 
 # Add conda installation dir to PATH (instead of doing 'conda activate')
 ENV PATH /opt/conda/envs/nf-core-diaproteomics-1.2.5dev/bin:$PATH
 
 # Dump the details of the installed packages to a file for posterity
-RUN conda env export --name nf-core-diaproteomics-1.2.5dev > nf-core-diaproteomics-1.2.5dev.yml
+RUN mamba env export --name nf-core-diaproteomics-1.2.5dev > nf-core-diaproteomics-1.2.5dev.yml
 
 # Install DIAlignR from GitHub
 RUN Rscript -e 'remotes::install_github("shubham1637/DIAlignR@2119587", dependencies=FALSE)'

--- a/environment.yml
+++ b/environment.yml
@@ -39,7 +39,6 @@ dependencies:
   - conda-forge::r-scales=1.1.1
   - conda-forge::r-reticulate=1.18
   - conda-forge::r-zoo=1.8_8
-  - conda-forge::r-remotes=2.2.0
   - bioconductor-MSstats=3.20.1
   - bioconductor-mzr=2.24.0
   - bioconductor-biocparallel=1.24.0

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - bioconda::pyprophet=2.1.4
   - conda-forge::networkx=2.4
   - bioconda::easypqp=0.1.8
+  - conda-forge::importlib-metadata=4.0.1
   - conda-forge::r-rmsnumpress=1.0.1
   - conda-forge::r-magrittr=2.0.1
   - conda-forge::r-bit64=4.0.5


### PR DESCRIPTION
Tested locally, seems to work fine (and quite quickly).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/diaproteomics/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/diaproteomics _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
