### PR TITLE
Dockerfile - alias mamba so that nf-core lint passes

### DIFF
--- a/.nf-core-lint.yml
+++ b/.nf-core-lint.yml
@@ -5,5 +5,3 @@ files_unchanged:
 # Temporary - ignore actions CI lint test until tools is updated with this code style
 # See https://github.com/nf-core/diaproteomics/pull/131
 actions_ci: False
-# Switched to mamba because conda refuses to build
-conda_dockerfile: False

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,18 @@ LABEL authors="Leon Bichmann" \
 
 # Install mamba
 RUN conda install mamba -n base -c conda-forge
+# Alias mamba to conda, so that nf-core lint sees the commands it expects
+RUN alias mamba=conda
 
 # Install the conda environment
 COPY environment.yml /
-RUN mamba env create --quiet -f /environment.yml && mamba clean -a
+RUN conda env create --quiet -f /environment.yml && conda clean -a
 
 # Add conda installation dir to PATH (instead of doing 'conda activate')
 ENV PATH /opt/conda/envs/nf-core-diaproteomics-1.2.5dev/bin:$PATH
 
 # Dump the details of the installed packages to a file for posterity
-RUN mamba env export --name nf-core-diaproteomics-1.2.5dev > nf-core-diaproteomics-1.2.5dev.yml
+RUN conda env export --name nf-core-diaproteomics-1.2.5dev > nf-core-diaproteomics-1.2.5dev.yml
 
 # Install DIAlignR from GitHub
 RUN Rscript -e 'remotes::install_github("shubham1637/DIAlignR@d323ad7", dependencies=FALSE)'


### PR DESCRIPTION
Used an `alias` so the we don't need to disable the `nf-core lint` test.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/diaproteomics/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/diaproteomics _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
